### PR TITLE
Dev - use provided enums for type checking

### DIFF
--- a/commands/fun/trivia.js
+++ b/commands/fun/trivia.js
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 import { decode } from "html-entities";
-import { EmbedBuilder } from "discord.js";
+import { ChannelType, EmbedBuilder } from "discord.js";
 import { stripIndents } from "common-tags";
 import { categories } from "../../core/util/data";
 
@@ -13,7 +13,7 @@ export const run = async (client, message, args) => {
     }
 
     // Let user know how many points they have
-    if (message.channel.type === "GUILD_TEXT") {
+    if (message.channel.type === ChannelType.GuildText) {
         const userData = await client.getUser(message.guild, message.author);
         const currentPoints = userData.triviaPoints;
         if (args[0] && args[0].toLowerCase() === "points") return message.reply(client.l10n(message, "trivia.points").replace(/%num%/g, currentPoints));
@@ -23,7 +23,7 @@ export const run = async (client, message, args) => {
     const lbAliases = ["leaderboard", "lb"];
     if (lbAliases.includes(args[0] && args[0].toLowerCase())) {
         // Return if leaderboard/lb arg is used in DMs
-        if (message.channel.type !== "GUILD_TEXT") return message.channel.send(`🚫 ${client.l10n(message, "trivia.dmlb")}`);
+        if (message.channel.type !== ChannelType.GuildText) return message.channel.send(`🚫 ${client.l10n(message, "trivia.dmlb")}`);
 
         // Fetch all users
         const all = await client.getUsers();
@@ -171,7 +171,7 @@ export const run = async (client, message, args) => {
                 ${client.l10n(message, "trivia.ans.gg")}`;
 
             // Add points (if in a guild text channel)
-            if (message.channel.type === "GUILD_TEXT") {
+            if (message.channel.type === ChannelType.GuildText) {
                 const dif = d.toLowerCase();
                 const points = { "easy": 1, "medium": 2, "hard": 3 };
 

--- a/commands/info/forecast.js
+++ b/commands/info/forecast.js
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import Canvas from "canvas";
 import { DateTime } from "luxon";
-import { AttachmentBuilder } from "discord.js";
+import { AttachmentBuilder, InteractionType } from "discord.js";
 import { stripIndents } from "common-tags";
 import { commandOptions } from "redis";
 import { sep } from "path";
@@ -50,7 +50,7 @@ export const run = async (client, message, args) => {
 
     // If using a regular command, start typing to indicate image is being generated.
     // Typing stops after 10 seconds, or once the message has been sent.
-    if (message.type !== "APPLICATION_COMMAND")
+    if (message.type !== InteractionType.ApplicationCommand)
         message.channel.sendTyping();
     // If using an application command, defer the response
     else
@@ -228,7 +228,7 @@ const sendImageAttachment = (message, buffer, isFromCache) => {
     const attachment = new AttachmentBuilder(buffer, isFromCache ? "forecast_cached.png" : "forecast.png");
     const filesObj = { files: [attachment] };
     
-    if (message.type !== "APPLICATION_COMMAND") message.reply(filesObj);
+    if (message.type !== InteractionType.ApplicationCommand) message.reply(filesObj);
     else message.editReply(filesObj);
 };
 

--- a/commands/info/user.js
+++ b/commands/info/user.js
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { EmbedBuilder } from "discord.js";
+import { ActivityType, EmbedBuilder } from "discord.js";
 import { stripIndents } from "common-tags";
 import { badge, statusIcon } from "../../core/util/data";
 
@@ -64,7 +64,7 @@ export const run = async (client, message, args) => {
 
     // If user has a current activity
     if (currentActivity) {
-        if (currentActivity.type === "CUSTOM") {
+        if (currentActivity.type === ActivityType.Custom) {
             // display their activity in the following format: [Emoji (if present)] [Status Message (if present)]
             activity = `${currentActivity.emoji ? currentActivity.emoji : "\u200b"} **${currentActivity.state ? currentActivity.state.truncate(24) : currentActivity.name}**`;
         } else {

--- a/commands/info/weather.js
+++ b/commands/info/weather.js
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import { DateTime } from "luxon";
 import { stripIndents } from "common-tags";
-import { EmbedBuilder } from "discord.js";
+import { EmbedBuilder, InteractionType } from "discord.js";
 
 const { OWM_KEY } = process.env;
 
@@ -21,7 +21,7 @@ export const run = async (client, message, args) => {
     const loc = encodeURIComponent(location);
 
     // Get two-letter language code for the "lang" parameter in the API request
-    const lang = message.type !== "APPLICATION_COMMAND" ? message.settings.language.slice(0, 2) || "en" : message.locale.substring(0, 2);
+    const lang = message.type !== InteractionType.ApplicationCommand ? message.settings.language.slice(0, 2) || "en" : message.locale.substring(0, 2);
 
     // Send GET request to OpenWeatherMap API for weather data
     const url = `https://api.openweathermap.org/data/2.5/weather?q=${loc}&units=metric&lang=${lang}&appid=${OWM_KEY}`;

--- a/commands/misc/help.js
+++ b/commands/misc/help.js
@@ -1,4 +1,4 @@
-import { EmbedBuilder } from "discord.js";
+import { ChannelType, EmbedBuilder, InteractionType } from "discord.js";
 import { stripIndents } from "common-tags";
 import { emoji, colour } from "../../core/util/data";
 
@@ -45,11 +45,11 @@ export const run = async (client, message, args, level) => {
 
         
         // If in a regular text channel...
-        if (message.channel.type === "GUILD_TEXT") {
+        if (message.channel.type === ChannelType.GuildText) {
             const helpConfirmTxt = `🏃‍♀️💨 ${client.l10n(message, "help.dmConfirm")}`;
 
             // if applicationcommand
-            if (message.type === "APPLICATION_COMMAND") {
+            if (message.type === InteractionType.ApplicationCommand) {
                 await message.reply(helpConfirmTxt);
                 message.user.send(out)
                     .catch(err => {
@@ -75,7 +75,7 @@ export const run = async (client, message, args, level) => {
                         return client.logger.error(err);
                     });
             }
-        } else if (message.channel.type === "DM") {
+        } else if (message.channel.type === ChannelType.DM) {
             // if the command is invoked in a DM channel, send the output 
             return message.reply(out, { split: { char: "\u200b" } });
         }

--- a/core/functions/l10n.js
+++ b/core/functions/l10n.js
@@ -1,6 +1,7 @@
 import locales from "../locales";
 import { readdirSync } from "fs";
 import { sep } from "path";
+import { InteractionType } from "discord.js";
 
 // Locale file directory
 const localeDir = `${process.cwd()}${sep}core${sep}locales`;
@@ -26,7 +27,7 @@ export default client => {
         const lf = localeFiles.map(file => file.split(".")[0]);
 
         // If the type of message is not an application command (assuming it is of type 'DEFAULT')...
-        if (message.type !== "APPLICATION_COMMAND") {
+        if (message.type !== InteractionType.ApplicationCommand) {
             // If a locale file matching the value of the "locale" parameter can't be found, return an error message
             if (!lf.includes(locale)) return client.logger.error(`Missing locale file: "${locale}"`);
 

--- a/core/functions/loadCommand.js
+++ b/core/functions/loadCommand.js
@@ -15,7 +15,8 @@ export default client => {
             client.logger.log(`✔ "${chalk.blue(name)}"`);
             return true;
         } catch (error) {
-            return `Unable to load command ${chalk.red(name)}: ${error}`;
+            client.logger.error(`Unable to load command ${chalk.red(name)}: ${error}`);
+            return false;
         }
     };
 };

--- a/core/settings/permLevels.js
+++ b/core/settings/permLevels.js
@@ -1,3 +1,5 @@
+import { ChannelType } from "discord.js";
+
 const permLevels = {
     superusers: [],
     
@@ -36,7 +38,7 @@ const permLevels = {
             name: "Server Owner",
             verify: message => {
                 try {
-                    if (message.channel.type === "GUILD_TEXT")
+                    if (message.channel.type === ChannelType.GuildText)
                         if (message.guild.ownerId === (message.author?.id || message.user?.id)) return true;
                 } catch (err) {
                     return false;

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -5,7 +5,7 @@ import { ChannelType, PermissionsBitField } from "discord.js";
 
 export default async (client, message) => {
     // Return if guild is unavailable (due to server outage)
-    if (message.channel.type !== "DM" && !message.guild.available) return;
+    if (message.channel.type !== ChannelType.DM && !message.guild.available) return;
 
     // Ignore messages from other bot accounts
     if (message.author.bot) return;

--- a/index.js
+++ b/index.js
@@ -106,9 +106,7 @@ const init = async () => {
             // Add command names to the "cmdArr" array so that the total amount of commands can be determined
             cmdArr.push(item.path);
             // Load each command that's found
-            const res = await client.loadCommand(file.dir, file.name);
-            // If the loadCommand function is unsuccessful, log the error
-            if (res !== true) client.logger.error(res);
+            await client.loadCommand(file.dir, file.name);
         })
         .on("end", () => client.logger.log(`Successfully loaded ${chalk.blue(cmdArr.length)} commands`));
 

--- a/interactions/context/userInfo.js
+++ b/interactions/context/userInfo.js
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { EmbedBuilder } from "discord.js";
+import { ActivityType, EmbedBuilder } from "discord.js";
 import { stripIndents } from "common-tags";
 import { badge, statusIcon } from "../../core/util/data";
 
@@ -58,7 +58,7 @@ export const run = async (client, interaction) => {
 
     // If user has a current activity
     if (currentActivity) {
-        if (currentActivity.type === "CUSTOM") {
+        if (currentActivity.type === ActivityType.Custom) {
             // display their activity in the following format: [Emoji (if present)] [Status Message (if present)]
             activity = `${currentActivity.emoji ? currentActivity.emoji : "\u200b"} **${currentActivity.state ? currentActivity.state.truncate(24) : currentActivity.name}**`;
         } else {


### PR DESCRIPTION
Discord.js provides enumerations for channel, activity, interaction (etc) types. This PR ensures that they are used, and also factors in the [breaking changes](https://discordjs.guide/additional-info/changes-in-v14.html#enum-values) made to enums between v13 and v14 of Discord.js.